### PR TITLE
Missing alarm data should be notBreaching

### DIFF
--- a/templates/cis-benchmark.template
+++ b/templates/cis-benchmark.template
@@ -1936,6 +1936,7 @@ Resources:
       Period: 60
       EvaluationPeriods: '1'
       Threshold: 1
+      TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -1971,6 +1972,7 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
+      TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -2010,6 +2012,7 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
+      TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -2109,6 +2112,7 @@ Resources:
       Period: '300'
       EvaluationPeriods: '1'
       Threshold: 1
+      TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
@@ -2146,6 +2150,7 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1
+      TreatMissingData: notBreaching
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
By default, alarms with missing data appear with a status of "INSUFFICIENT_DATA," which is somewhat misleading. Using the "notBreaching" property will instead display the status of "OK."